### PR TITLE
Make scope of the unpack method configurable.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -69,6 +69,17 @@
 			});
 			assert.strictEqual(scope, t);
 		});
+
+		test('can be called with custom scope', function () {
+			var t = new Tuple();
+			var bogusScope = {humpty:'dumpty'};
+			var scope;
+			t.unpack(function () {
+				scope = this;
+			}, bogusScope);
+			assert.strictEqual(scope, bogusScope);
+		});
+
 	});
 
 	suite('Tuple#toString()', function () {

--- a/tuple.js
+++ b/tuple.js
@@ -34,10 +34,12 @@
 	 * returns.
 	 *
 	 * @param {Function} unpacker Is passed all of the tuples values in order, it's return value will be returned.
+	 * @param {Object} scope The optional scope (value of `this`) when executing the unpacker-function. Will
+	 * 	default to the respective instance of `Tuple` if not specified.
 	 * @return {*} The value that the unpacker function returns.
 	 */
-	Tuple.prototype.unpack = function unpack(unpacker) {
-		return unpacker.apply(this, this);
+	Tuple.prototype.unpack = function unpack(unpacker, scope) {
+		return unpacker.apply(scope || this, this);
 	};
 
 	/**


### PR DESCRIPTION
When `unpack`ing, people might want to use a method which should be executed in a specific scope.

This pull request implements this behavior by introducing a new optional argument `scope` for the `unpack` method.
